### PR TITLE
Added suport for .NET binary serialization

### DIFF
--- a/YamlDotNet.Dynamic.Test/DynamicYamlTest.cs
+++ b/YamlDotNet.Dynamic.Test/DynamicYamlTest.cs
@@ -28,8 +28,26 @@ using Xunit;
 
 namespace YamlDotNet.Dynamic.Test
 {
+	using System.IO;
+	using System.Runtime.Serialization.Formatters.Binary;
+
+	using YamlDotNet.RepresentationModel;
+
 	public class DynamicYamlTest
 	{
+		[Fact]
+		public void TestDynamicYamlIsSerializeable()
+		{
+			dynamic dynamicYaml = new DynamicYaml(MappingYaml);
+			var formatter = new BinaryFormatter();
+			var stream = new MemoryStream();
+			formatter.Serialize(stream, dynamicYaml);
+			
+			stream.Position = 0;
+			dynamic result = formatter.Deserialize(stream);
+			Assert.Equal((YamlNode)dynamicYaml.yamlNode, (YamlNode)result.yamlNode);
+		}
+
 		[Fact]
 		public void TestMappingNode()
 		{

--- a/YamlDotNet.Dynamic/DynamicYaml.cs
+++ b/YamlDotNet.Dynamic/DynamicYaml.cs
@@ -31,6 +31,7 @@ using YamlDotNet.RepresentationModel;
 
 namespace YamlDotNet.Dynamic
 {
+	[Serializable]
 	public class DynamicYaml : DynamicObject
 	{
 		private static readonly Type[] ConvertableBasicTypes =


### PR DESCRIPTION
Adding the Serializable attribute to YamlNode allows the YamlNode object graph to be easily deep cloned / marshalled across processes with BinarySerlialization. Deep cloning is particularly useful within parallelized environments.

We have used this change successfully for about a month now.
