### PR TITLE
Reference YamlDotNet 4.3.0 and fix usage of removed implicit cast

### DIFF
--- a/YamlDotNet.Dynamic.Test/YamlDotNet.Dynamic.Test.csproj
+++ b/YamlDotNet.Dynamic.Test/YamlDotNet.Dynamic.Test.csproj
@@ -51,9 +51,8 @@
     <Reference Include="xunit.extensions">
       <HintPath>..\packages\xunit.extensions.1.9.1\lib\net20\xunit.extensions.dll</HintPath>
     </Reference>
-    <Reference Include="YamlDotNet, Version=3.3.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\YamlDotNet.3.3.0\lib\net35\YamlDotNet.dll</HintPath>
+    <Reference Include="YamlDotNet, Version=4.3.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\YamlDotNet.4.3.0\lib\net35\YamlDotNet.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/YamlDotNet.Dynamic.Test/packages.config
+++ b/YamlDotNet.Dynamic.Test/packages.config
@@ -3,5 +3,5 @@
   <package id="FluentAssertions" version="2.1.0.0" targetFramework="net40" />
   <package id="xunit" version="1.9.1" targetFramework="net40" />
   <package id="xunit.extensions" version="1.9.1" targetFramework="net40" />
-  <package id="YamlDotNet" version="3.3.0" targetFramework="net40" />
+  <package id="YamlDotNet" version="4.3.0" targetFramework="net40" />
 </packages>

--- a/YamlDotNet.Dynamic/DynamicYaml.cs
+++ b/YamlDotNet.Dynamic/DynamicYaml.cs
@@ -141,7 +141,7 @@ namespace YamlDotNet.Dynamic
 			}
 
 			// try and get an exact match to the key first
-			if (TryGetValueByYamlKeyAndType(key, type, out result))
+			if (TryGetValueByYamlKeyAndType(new YamlScalarNode(key), type, out result))
 			{
 				return true;
 			}

--- a/YamlDotNet.Dynamic/YamlDotNet.Dynamic.csproj
+++ b/YamlDotNet.Dynamic/YamlDotNet.Dynamic.csproj
@@ -40,9 +40,8 @@
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
-    <Reference Include="YamlDotNet, Version=3.3.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\YamlDotNet.3.3.0\lib\net35\YamlDotNet.dll</HintPath>
+    <Reference Include="YamlDotNet, Version=4.3.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\YamlDotNet.4.3.0\lib\net35\YamlDotNet.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/YamlDotNet.Dynamic/packages.config
+++ b/YamlDotNet.Dynamic/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="YamlDotNet" version="3.3.0" targetFramework="net40" />
+  <package id="YamlDotNet" version="4.3.0" targetFramework="net40" />
 </packages>


### PR DESCRIPTION
I see this hasn't had recent updates but it would be useful to use it with YamlDotNet 4.3.0.